### PR TITLE
Added `withSettings` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Extended ACF provides an object oriented API to register groups and fields with 
 - [Fields](#fields)
 - [Location](#location)
 - [Conditional Logic](#conditional-logic)
-- [Custom Configuration](#custom-configuration)
+- [Custom Settings](#custom-settings)
 - [Custom Fields](#custom-fields)
 - [Upgrade Guide](#upgrade-guide)
 
@@ -627,9 +627,17 @@ Url::make('Link', 'url')
     ]),
 ```
 
-## Custom Configuration
+## Custom Settings
 
-If you want to add custom settings to the fields, you can extend the field classes available in this library.
+If you want to add custom settings to the fields, you can use the `with` method.
+
+```php
+Text::make('Name')
+	->with(['key' => 'value'])
+	->required()
+```
+
+Another option is to extend field classes available in the package.
 
 ```php
 namespace App\Fields;

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ If you want to add custom settings to the fields, you can use the `with` method.
 
 ```php
 Text::make('Name')
-	->with(['key' => 'value'])
+	->withSettings(['key' => 'value'])
 	->required()
 ```
 

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ Url::make('Link', 'url')
 
 ## Custom Settings
 
-If you want to add custom settings to the fields, you can use the `with` method.
+If you want to add custom settings to the fields, you can use the `with` method. Please note that if you use settings which are already registerd on the field, they'll be overwritten.
 
 ```php
 Text::make('Name')

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -36,7 +36,7 @@ abstract class Field
     }
 
     /** @throws \InvalidArgumentException */
-    public function with(array $settings): static
+    public function withSettings(array $settings): static
     {
         $invalidKeys = [
             'collapsed',

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Extended\ACF\Fields;
 
 use Extended\ACF\Key;
+use InvalidArgumentException;
 
 abstract class Field
 {
@@ -32,6 +33,30 @@ abstract class Field
     public static function make(string $label, string|null $name = null): static
     {
         return new static($label, $name);
+    }
+
+    /** @throws \InvalidArgumentException */
+    public function with(array $settings): static
+    {
+        $invalidKeys = [
+            'collapsed',
+            'conditional_logic',
+            'key',
+            'label',
+            'layouts',
+            'sub_fields',
+            'type',
+        ];
+
+        foreach ($invalidKeys as $key) {
+            if (array_key_exists($key, $settings)) {
+                throw new InvalidArgumentException("Invalid setting key [$key].");
+            }
+        }
+
+        $this->settings = array_merge($this->settings, $settings);
+
+        return $this;
     }
 
     /** @internal */

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -44,6 +44,7 @@ abstract class Field
             'key',
             'label',
             'layouts',
+            'name',
             'sub_fields',
             'type',
         ];

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -51,7 +51,7 @@ abstract class Field
 
         foreach ($invalidKeys as $key) {
             if (array_key_exists($key, $settings)) {
-                throw new InvalidArgumentException("Invalid setting key [$key].");
+                throw new InvalidArgumentException("Invalid settings key [$key].");
             }
         }
 

--- a/tests/Fields/TextTest.php
+++ b/tests/Fields/TextTest.php
@@ -15,6 +15,7 @@ namespace Extended\ACF\Tests\Fields;
 
 use Extended\ACF\ConditionalLogic;
 use Extended\ACF\Fields\Text;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class TextTest extends TestCase
@@ -44,6 +45,16 @@ class TextTest extends TestCase
     {
         $field = Text::make('Text')->get();
         $this->assertSame('text', $field['type']);
+    }
+
+    public function testWith()
+    {
+        $field = Text::make('Text With')->with(['custom' => 'setting'])->get();
+        $this->assertSame('setting', $field['custom']);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        Text::make('Text With Label')->with(['label' => 'invalid'])->get();
     }
 
     public function testReadOnly()

--- a/tests/Fields/TextTest.php
+++ b/tests/Fields/TextTest.php
@@ -47,14 +47,14 @@ class TextTest extends TestCase
         $this->assertSame('text', $field['type']);
     }
 
-    public function testWith()
+    public function testWithSettings()
     {
-        $field = Text::make('Text With')->with(['custom' => 'setting'])->get();
+        $field = Text::make('Text With Settings')->withSettings(['custom' => 'setting'])->get();
         $this->assertSame('setting', $field['custom']);
 
         $this->expectException(InvalidArgumentException::class);
 
-        Text::make('Text With Label')->with(['label' => 'invalid'])->get();
+        Text::make('Text With Settings Label')->withSettings(['label' => 'invalid'])->get();
     }
 
     public function testReadOnly()


### PR DESCRIPTION
Added `withSettings` settings helper method to allow custom settings on fields:

```php
Text::make('Name')
	->withSettings(['custom' => 'setting'])
	->required()
```

This closes #115 