### PR TITLE
Removed unnecessary `layout` prefix for flexible content field layouts

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -19,7 +19,6 @@ use InvalidArgumentException;
 abstract class Field
 {
     protected array $settings;
-    protected string $keyPrefix = 'field';
     protected string|null $type = null;
 
     public function __construct(string $label, string|null $name = null)
@@ -92,7 +91,7 @@ abstract class Field
             }
         }
 
-        $this->settings['key'] = Key::generate($key, $this->keyPrefix);
+        $this->settings['key'] = Key::generate($key, 'field');
 
         return $this->settings;
     }

--- a/src/Fields/Layout.php
+++ b/src/Fields/Layout.php
@@ -22,8 +22,6 @@ class Layout extends Field
     use MinMax;
     use SubFields;
 
-    protected string $keyPrefix = 'layout';
-
     /**
      * @param string $layout block, row or table
      * @throws \InvalidArgumentException


### PR DESCRIPTION
With the release of [6.0.7](https://www.advancedcustomfields.com/blog/acf-6-0-7/), ACF removed unnecessary `layout` prefix for flexible content field layouts. 

Since this package is generating field keys on the fly, this should be regarded as a breaking change and released in a major version. It would probably also make it harder to upgrade to a newer version if the layout prefix is saved in the database. I'm guessing removing the prefix won't benefit this library much, and we can probably leave it as is.

@lgladdy am I right to assume that the layout prefixes are saved in the database?