### PR TITLE
merge column() width into wrapper() array to avoid overwrites

### DIFF
--- a/src/Fields/Settings/Wrapper.php
+++ b/src/Fields/Settings/Wrapper.php
@@ -17,6 +17,12 @@ trait Wrapper
 {
     public function wrapper(array $wrapper): static
     {
+        $column_width = $this->settings['wrapper']['width'] ?? null;
+
+        if ($column_width !== null) {
+          $wrapper['width'] = $column_width;
+        }
+        
         $this->settings['wrapper'] = $wrapper;
 
         return $this;


### PR DESCRIPTION
@vinkla based on issue #134, this PR modifies the wrapper() method to check if a width setting already exists (in which case we know column() was already called), and if so merges it into the array provided to wrapper().

It currently makes the assumption that the width provided to column() will always take precedence over a width provided to wrapper(), even if wrapper() is called after column(); let me know if that isn't ideal. 

Examples:

This now works (wrapper doesn't override column's width, and wrapper's other attributes still take effect):
```php
Text::make('Title')
   ->column(50)
   ->wrapper(['class' => 'testing'])
```

Below, even though wrapper sets width to 40% AFTER column sets it to 50%, the final width will be 50% -- does this seem right? Or should it be whoever sets it last wins?
```php
Text::make('Title')
   ->column(50)
   ->wrapper(['class' => 'testing', 'width' => '40%'])
```