### PR TITLE
Added custom field key method

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -73,8 +73,8 @@ abstract class Field
     }
 
     /**
-     * In most cases, it is not necessary to set a custom key. Let the package
-     * generate the key for you. Please use this method with caution.
+     * In most cases, there is no need to set a custom key. It is recommended to
+     * let the package generate the key for you. Please use this method carefully.
      * @throws \InvalidArgumentException
      */
     public function key(string $key): static

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -85,11 +85,13 @@ abstract class Field
             );
         }
 
-        if (array_key_exists($key, Key::$keys)) {
+        if (in_array($key, array_values(Key::$keys))) {
             throw new InvalidArgumentException("The key [$key] is not unique.");
         }
 
         $this->settings['key'] = $key;
+
+        Key::$keys[] = $key;
 
         return $this;
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
 
 class Key
 {
-    protected static array $keys = [];
+    public static array $keys = [];
 
     /** @throws \InvalidArgumentException */
     public static function generate(string $key, string $prefix): string

--- a/tests/Fields/TextTest.php
+++ b/tests/Fields/TextTest.php
@@ -40,6 +40,21 @@ class TextTest extends TestCase
     {
         $field = Text::make('Phone')->get();
         $this->assertSame('field_16217cde', $field['key']);
+
+        $field = Text::make('Phone')->key('field_12345')->get();
+        $this->assertSame('field_1234567', $field['key']);
+    }
+
+    public function testKeyUniqueness()
+    {
+        $this->expectExceptionMessage('The key [field_16217cde] is not unique.');
+        Text::make('Phone')->key('field_16217cde')->get();
+    }
+
+    public function testKeyPrefix()
+    {
+        $this->expectExceptionMessage('The key should have the prefix [field_].');
+        Text::make('Phone')->key('phone')->get();
     }
 
     public function testType()

--- a/tests/Fields/TextTest.php
+++ b/tests/Fields/TextTest.php
@@ -41,7 +41,7 @@ class TextTest extends TestCase
         $field = Text::make('Phone')->get();
         $this->assertSame('field_16217cde', $field['key']);
 
-        $field = Text::make('Phone')->key('field_12345')->get();
+        $field = Text::make('Phone')->key('field_1234567')->get();
         $this->assertSame('field_1234567', $field['key']);
     }
 


### PR DESCRIPTION
This pull request adds support for custom field keys, which can be useful when working with older versions of this package or generating existing fields from the ACF dashboard. However, there are some quirks that need to be fixed. We should add assertions and thoroughly test this feature, as the generated keys are crucial in this package. Additionally, we should not document this feature extensively and clearly emphasise that it should only be used with caution.

```php
Text::make('Name')
    ->key('field_123456789');
```

It verifies whether the field key is prefixed with `field_` or `layout_`. However, this may pose a problem if someone has registered fields without these prefixes. 