### PR TITLE
add getSettings and getType getter methods

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -72,6 +72,16 @@ abstract class Field
         dd($this->get(), ...$args);
     }
 
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    public function getType(): string|null
+    {
+        return $this->type;
+    }
+
     /**
      * In most cases, there is no need to set a custom key. It is recommended to
      * let the package generate the key for you. Please use this method carefully.


### PR DESCRIPTION
@vinkla This simple PR adds getter methods, `getSettings` and `getType`, to the `Field` class, enabling users to access (read-only) the protected properties `settings` and `type`. I personally came across the need for this because I'm writing some code that processes my fields and needs to conditionally do stuff based on field types & settings -- but they're currently inaccessible outside the Field class.

Please let me know your thoughts or if I'm missing anything! :)