### PR TITLE
Fix Key::resolveParentKey traversal process

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -58,14 +58,14 @@ class Key
         $parentKeyPieces = explode('_', $parentKey);
 
         while (count($parentKeyPieces) > 1) {
-            array_pop($parentKeyPieces);
-
             $potentialParentKey = implode('_', $parentKeyPieces);
             $potentialKey = $potentialParentKey . '_' . $key;
 
             if (array_key_exists($potentialKey, self::$keys)) {
                 return $potentialParentKey;
             }
+
+            array_pop($parentKeyPieces);
         }
 
         return $parentKey;


### PR DESCRIPTION
Hi @vinkla, I believe I found a simple edge-case bug in the `Key::resolveParentKey` method, where it traverses the parent key to find the potential parent key. Currently, the use of `array_pop` happens at the beginning of the loop, rather than at the end, resulting in not checking the first potential parent key. This has probably gone unnoticed because the method falls back to returning the `$parentKey` that was initially provided, which in probably 99% of cases is the correct key. If you step through the code with XDebug, you should notice that the traversal process never finds a key and the fallback return always occurs, unless it happens to find a valid key further up the parent key tree which likely causes incorrect conditional logic (which is what I experienced and led me to finding this). Moving `array_pop` to the end of the loop fixed the bug I was experiencing, doesn't break anything (as far as I could tell with manual tests in a large project), and should bring a tiny performance improvement because it should result in the parent key traversal process correctly cutting short in most cases.