### PR TITLE
Adjust dump method in Extended\ACF\Fields\Field to utilize object cloning

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -110,21 +110,21 @@ abstract class Field
 
         if (isset($this->settings['conditional_logic'])) {
             $this->settings['conditional_logic'] = array_map(
-                fn($rules) => $rules->get($parentKey),
+                fn($rules) => is_object($rules) ? (clone $rules)->get($parentKey) : $rules,
                 $this->settings['conditional_logic'],
             );
         }
 
         if (isset($this->settings['layouts'])) {
             $this->settings['layouts'] = array_map(
-                fn($layout) => $layout->get($key),
+                fn($layout) => is_object($layout) ? (clone $layout)->get($key) : $layout,
                 $this->settings['layouts'],
             );
         }
 
         if (isset($this->settings['sub_fields'])) {
             $this->settings['sub_fields'] = array_map(
-                fn($field) => $field->get($key),
+                fn($field) => is_object($field) ? (clone $field)->get($key) : $field,
                 $this->settings['sub_fields'],
             );
         }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -62,8 +62,7 @@ abstract class Field
 
     public function dump(...$args): static
     {
-        $clone = $this->deepClone();
-        $settings = $clone->get();
+        $settings = $this->cloneRecursively()->get();
 
         dump($settings, ...$args);
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -110,21 +110,21 @@ abstract class Field
 
         if (isset($this->settings['conditional_logic'])) {
             $this->settings['conditional_logic'] = array_map(
-                fn($rules) => is_object($rules) ? (clone $rules)->get($parentKey) : $rules,
+                fn($rules) => $rules->get($parentKey),
                 $this->settings['conditional_logic'],
             );
         }
 
         if (isset($this->settings['layouts'])) {
             $this->settings['layouts'] = array_map(
-                fn($layout) => is_object($layout) ? (clone $layout)->get($key) : $layout,
+                fn($layout) => $layout->get($key),
                 $this->settings['layouts'],
             );
         }
 
         if (isset($this->settings['sub_fields'])) {
             $this->settings['sub_fields'] = array_map(
-                fn($field) => is_object($field) ? (clone $field)->get($key) : $field,
+                fn($field) => $field->get($key),
                 $this->settings['sub_fields'],
             );
         }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -62,7 +62,10 @@ abstract class Field
 
     public function dump(...$args): static
     {
-        dump($this->get(), ...$args);
+        $clone = clone $this;
+        $settings = $clone->get();
+
+        dump($settings, ...$args);
 
         return $this;
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -151,7 +151,7 @@ abstract class Field
 
         if (isset($this->settings['sub_fields'])) {
             $clone->settings['sub_fields'] = array_map(
-                fn($field) => $field->deepClone(),
+                fn(Field $field) => $field->cloneRecursively(),
                 $this->settings['sub_fields']
             );
         }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -144,6 +144,7 @@ abstract class Field
 
         return $this->settings;
     }
+
     /** @internal */
     private function cloneRecursively(): static
     {
@@ -152,7 +153,7 @@ abstract class Field
         if (isset($this->settings['sub_fields'])) {
             $clone->settings['sub_fields'] = array_map(
                 fn(Field $field) => $field->cloneRecursively(),
-                $this->settings['sub_fields']
+                $this->settings['sub_fields'],
             );
         }
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -145,10 +145,7 @@ abstract class Field
         return $this->settings;
     }
 
-    /**
-     * Deep clone the current object and all nested fields.
-     */
-    protected function deepClone(): static
+    private function cloneRecursively(): static
     {
         $clone = clone $this;
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -144,7 +144,7 @@ abstract class Field
 
         return $this->settings;
     }
-
+    /** @internal */
     private function cloneRecursively(): static
     {
         $clone = clone $this;

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -62,7 +62,7 @@ abstract class Field
 
     public function dump(...$args): static
     {
-        $clone = clone $this;
+        $clone = $this->deepClone();
         $settings = $clone->get();
 
         dump($settings, ...$args);
@@ -144,5 +144,22 @@ abstract class Field
         $this->settings['key'] ??= Key::generate($key, $this->keyPrefix);
 
         return $this->settings;
+    }
+
+    /**
+     * Deep clone the current object and all nested fields.
+     */
+    protected function deepClone(): static
+    {
+        $clone = clone $this;
+
+        if (isset($this->settings['sub_fields'])) {
+            $clone->settings['sub_fields'] = array_map(
+                fn($field) => $field->deepClone(),
+                $this->settings['sub_fields']
+            );
+        }
+
+        return $clone;
     }
 }


### PR DESCRIPTION
_This PR will fix #153._ 

### Description
This pull request refactors the get method in the Extended\ACF\Fields\Field class to utilize PHP object cloning. The changes ensure that field instances, particularly those with sub_fields, layouts, and conditional_logic, are processed independently, preventing unintended modifications to the original objects during method execution.

### Changes Made
- Object Cloning: Implemented object cloning in the get method to create independent instances of sub_fields, layouts, and conditional_logic before processing.
- Safety Checks: Added conditional checks to ensure clone is only applied to objects, safeguarding against potential errors when dealing with non-object types.