### PR TITLE
Add support for field group position

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -33,6 +33,8 @@ if (!function_exists('register_extended_field_group')) {
 
         $settings['style'] ??= 'seamless';
 
+        $settings['position'] ??= 'normal';
+
         $settings['fields'] = array_map(fn($field) => $field->get($key), $settings['fields']);
 
         $settings['location'] = array_map(fn($location) => $location->get(), $settings['location']);


### PR DESCRIPTION
**Description**
This pull request adds support for the ACF native field group setting `position`. Defaults to `normal`. This feature is documented under [Register fields via PHP](https://www.advancedcustomfields.com/resources/register-fields-via-php/#group-settings) in the ACF documentation.