### PR TITLE
feat: add create and save methods to Select field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 14.4.0
+
+- Added `create` method to select field
+- Added `save` method to select field
+
 ## 14.3.0
 
 - Added bidirectional relationship method

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Select::make('Color')
     ->nullable()
     ->stylized() // stylized checkbox using select2
     ->lazyLoad() // use AJAX to lazy load choices
+    ->create() // allow creation of new options
+    ->save() // save new options to the choices
     ->required()
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "14.3-dev"
+            "dev-master": "14.4-dev"
         }
     }
 }

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -55,6 +55,25 @@ class Select extends Field
         return $this;
     }
 
+    public function create(): static
+    {
+        $this->settings['ui'] = true;
+        $this->settings['multiple'] = true;
+        $this->settings['create_options'] = true;
+
+        return $this;
+    }
+
+    public function save(): static
+    {
+        $this->settings['ui'] = true;
+        $this->settings['multiple'] = true;
+        $this->settings['create_options'] = true;
+        $this->settings['save_options'] = true;
+
+        return $this;
+    }
+
     /**
      * @param string $format array, label, value
      * @throws \InvalidArgumentException

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -65,4 +65,21 @@ class SelectTest extends FieldTestCase
         $this->assertTrue($field['ui']);
         $this->assertTrue($field['ajax']);
     }
+
+    public function testCreate()
+    {
+        $field = Select::make('Select Create')->create()->get();
+        $this->assertTrue($field['ui']);
+        $this->assertTrue($field['multiple']);
+        $this->assertTrue($field['create_options']);
+    }
+
+    public function testSave()
+    {
+        $field = Select::make('Select Save')->save()->get();
+        $this->assertTrue($field['ui']);
+        $this->assertTrue($field['multiple']);
+        $this->assertTrue($field['create_options']);
+        $this->assertTrue($field['save_options']);
+    }
 }


### PR DESCRIPTION
> New – Select fields can now be configured to allow creating new options when editing the field’s value (requires the “Stylized UI” and “Multiple” field settings to be enabled)

[These were introduced in 6.4.1.](https://www.advancedcustomfields.com/blog/acf-6-4-1/)